### PR TITLE
Replace `keys` with `getOwnPropertyNames`

### DIFF
--- a/src/create-spy-from-class.ts
+++ b/src/create-spy-from-class.ts
@@ -131,7 +131,7 @@ function getAllMethodNames(obj: any): string[] {
   let methods: string[] = [];
 
   do {
-    methods = methods.concat(Object.keys(obj));
+    methods = methods.concat(Object.getOwnPropertyNames(obj));
     obj = Object.getPrototypeOf(obj);
   } while (obj);
 


### PR DESCRIPTION
`Object.keys` does not support `non-enumerables` (https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/keys#Examples). This prevents `Object.keys` from getting the actual properties.  `Object.getOwnPropertyNames` solves this issue.